### PR TITLE
Add JSON example to recon template formats

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -356,6 +356,7 @@ Name | Format | Valid values | Description
     </#list>
 </#list>
 ```
+
 > - **Note:** Reconciliation templates follow a slightly different format than Export Templates. The basic iterative skeleton of the template is:
 
 ```
@@ -369,6 +370,29 @@ Name | Format | Valid values | Description
      </#list>
 </#list>
 ```
+
+> - Template sample for a JSON array output.
+
+```
+[<#lt>
+<#list cards as card, reports>
+  <#list reports as report>
+      <#list report.transactionList as expense>
+        {<#lt>
+              "Original Merchant": "${expense.originalMerchant}",<#lt>
+              "Posted date": "${expense.posted}",<#lt>
+              "Sales date": "${expense.originalCreated}",<#lt>
+              "Modified Salesdate": "${expense.modifiedCreated}",<#lt>
+              "Original Amount": ${(-expense.originalAmount/100)?string("0.00")},<#lt>
+              "Modified Amount": ${expense.amountModified?then((-expense.originalAmount/100)?string("0.00"), "")}<#lt>
+        }<#sep>,</#sep><#lt>
+      </#list>
+    </#list>
+</#list>
+]
+```
+
+> - **Note:** To output a `.json` file, one would change the `fileExtension` parameter of `outputSettings` to "json".
 
 The `template` parameter is used to format the Expensify data as you wish. It is based on the Freemarker language's syntax.
 


### PR DESCRIPTION
@francoisl please review

for https://github.com/Expensify/Expensify/issues/86119

Add a JSON example to recon template formats

<img width="1276" alt="screen shot 2018-08-28 at 7 11 35 pm" src="https://user-images.githubusercontent.com/4741899/44760984-37d23580-aaf6-11e8-8058-17bc14212392.png">
