### PR TITLE
Remove outdated description for Employee Getter API

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -880,7 +880,7 @@ curl -X POST 'https://integrations.expensify.com/Integration-Server/ExpensifyInt
 }
 ```
 
-Lets you get specific information about listed policies. At this time, only category, report field, tag, and tax information is supported.
+Lets you get specific information about listed policies.
 
 - `inputSettings`
 


### PR DESCRIPTION
This was reported by a customer to @tjferriss.

The list of supported fields is just below in the table.