### PR TITLE
Fix line break in API doc bullet list

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -68,6 +68,7 @@ credentials | JSON object | An object containing two key/values used to authenti
 # Rate limits
 
 To keep our platform stable and handle high traffic, Expensify limits how many API requests you can send:
+
 - Up to 5 requests every 10 seconds
 - Up to 20 requests every 60 seconds
 


### PR DESCRIPTION
Add a missing line break that's preventing markdown from rendering a list as `<ul>` 😑

Before | After
--- | ---
<img width="648" alt="image" src="https://github.com/user-attachments/assets/4b23f341-fdbc-48a0-938a-bc809855362b" /> | <img width="645" alt="image" src="https://github.com/user-attachments/assets/b66a79ac-7bcd-4748-9da6-cc4c40b9ea8c" />
