### PR TITLE
makes it clearer that the approvedAfter date itself is inclusive.

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -197,7 +197,7 @@ reportIDList | String, <br/>*Required if `startDate` or `approvedAfter` are not 
 policyIDList | String, <br/>*Optional* |  | Comma-separated list of policy IDs the exported reports must be under.
 startDate | Date, <br/>*Required if `reportIDList` or `approvedAfter` are not specified* | yyyy-mm-dd formatted date | Filters out all reports submitted or created before the given date, whichever occurred last (inclusive).
 endDate | Date, <br/> *Conditionally required, if either `startDate` or `approvedAfter` is more than one year ago* | yyyy-mm-dd formatted date | Filters out all reports submitted or created after the given date, whichever occurred last (inclusive).<br/>The total date range cannot exceed one year. |
-approvedAfter | Date, <br/>*Required if `reportIDList` or `startDate` are not specified* | yyyy-mm-dd formatted date | Filters out all reports approved before, or on that date. This filter is only used against reports that have been approved. |
+approvedAfter | Date, <br/>*Required if `reportIDList` or `startDate` are not specified* | yyyy-mm-dd formatted date | Filters out all reports approved before that date (the date itself is inclusive). This filter is only used against reports that have been approved. |
 markedAsExported | String,<br/>*Optional* | Any string | Filters out reports that have already been exported with that label out.
 
 - `outputSettings`


### PR DESCRIPTION
Mirror of Expensify/Integration-Server#8743 — makes it clearer that the approvedAfter date itself is inclusive.

Make sure you've checked off all these things before submitting:

- [x] This pull request isn't for a company's fork, it's intended for the upstream Slate shared by everybody.
- [x] This pull request is submitted to the `dev` branch.
- [x] If it makes frontend changes, this pull request has been tested in the latest version of Firefox, Chrome, IE, and Safari.
